### PR TITLE
[TH2-5060] Support for BigInteger in th2 transport parsed messages and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-# th2 Sailfish Utils (4.1.0)
+# th2 Sailfish Utils (4.1.1)
 
 This library contains classes to convert messages from th2 to Sailfish format and vice versa. They are used in several
 th2 projects to reuse Sailfish features: message comparison, codec/connect implementations, etc.
 
 ## Release Notes
+
+### 4.1.1
+
++ Added support for `BigInteger` values in th2 transport parsed messages.
++ Added support for `BigInteger` in comparison filters (to compare big integer numbers)
 
 ### 4.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-release_version=4.1.0
+release_version=4.1.1
 description='th2 sailfish utils'
 kotlin_version=1.8.22
 vcs_url=https://github.com/th2-net/th2-sailfish-utils

--- a/src/main/java/com/exactpro/th2/sailfish/utils/filter/CompareFilter.java
+++ b/src/main/java/com/exactpro/th2/sailfish/utils/filter/CompareFilter.java
@@ -16,11 +16,13 @@
 package com.exactpro.th2.sailfish.utils.filter;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 import java.util.Objects;
+import java.util.function.Function;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -82,7 +84,7 @@ public class CompareFilter extends AbstractNotNullFilter {
         Comparable<?> tmpValue;
         if (isNumber) {
             try {
-                tmpValue = Objects.requireNonNull(FilterUtils.convertNumberValue(value));
+                tmpValue = Objects.requireNonNull(FilterUtils.convertNumberValue((String) value));
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException("Failed to parse value to Number. Value = " + value, e);
             }
@@ -148,6 +150,9 @@ public class CompareFilter extends AbstractNotNullFilter {
             if (first instanceof BigDecimal) {
                 return ((BigDecimal)first).compareTo((BigDecimal)second);
             }
+            if (first instanceof BigInteger) {
+                return ((BigInteger) first).compareTo((BigInteger) second);
+            }
             return ((Long)first).compareTo((Long)second);
         }
         if (first instanceof LocalDate || first instanceof LocalDateTime || first instanceof LocalTime) {
@@ -156,17 +161,52 @@ public class CompareFilter extends AbstractNotNullFilter {
         if (second instanceof LocalDate || second instanceof LocalDateTime || second instanceof LocalTime) {
             throw new IllegalArgumentException(String.format("Failed to compare Temporal values {%s}, {%s}", first, second));
         }
-        if (first instanceof BigDecimal) {
-            return ((BigDecimal)first).compareTo(new BigDecimal(second.toString()));
+        var result = compareWithTransformation(BigDecimal.class, first, second, it -> new BigDecimal(it.toString()));
+        if (result.matchType) {
+            return result.comparisonResult;
         }
-        if (second instanceof BigDecimal) {
-            return new BigDecimal(first.toString()).compareTo((BigDecimal)second);
+        result = compareWithTransformation(BigInteger.class, first, second, it -> new BigInteger(it.toString()));
+        if (result.matchType) {
+            return result.comparisonResult;
         }
-        return ((Long)first).compareTo((Long)second);
+        return Long.valueOf(first.toString()).compareTo(Long.valueOf(second.toString()));
     }
 
     @Override
     public FilterOperation getOperation() {
         return operation;
+    }
+
+    private static class CompareResult {
+        private final boolean matchType;
+        private final int comparisonResult;
+
+        private CompareResult(boolean matchType, int result) {
+            this.matchType = matchType;
+            this.comparisonResult = result;
+        }
+    }
+
+    private static CompareResult match(int result) {
+        return new CompareResult(true, result);
+    }
+
+    private static CompareResult mismatch() {
+        return new CompareResult(false, 0);
+    }
+
+    private static <T extends Comparable<T>> CompareResult compareWithTransformation(
+            Class<T> type,
+            Object first,
+            Object second,
+            Function<Object, T> transform
+    ) {
+        if (type.isInstance(first)) {
+            return match(type.cast(first).compareTo(transform.apply(second)));
+        }
+        if (type.isInstance(second)) {
+            return match(transform.apply(first).compareTo(type.cast(second)));
+        }
+        return mismatch();
     }
 }

--- a/src/main/java/com/exactpro/th2/sailfish/utils/filter/CompareFilter.java
+++ b/src/main/java/com/exactpro/th2/sailfish/utils/filter/CompareFilter.java
@@ -161,6 +161,10 @@ public class CompareFilter extends AbstractNotNullFilter {
         if (second instanceof LocalDate || second instanceof LocalDateTime || second instanceof LocalTime) {
             throw new IllegalArgumentException(String.format("Failed to compare Temporal values {%s}, {%s}", first, second));
         }
+
+        // There only 3 possible types for numbers: BigDecimal, BigInteger, Long
+        // If none of them is passed to this method then something went wrong
+
         var result = compareWithTransformation(BigDecimal.class, first, second, it -> new BigDecimal(it.toString()));
         if (result.matchType) {
             return result.comparisonResult;
@@ -169,7 +173,13 @@ public class CompareFilter extends AbstractNotNullFilter {
         if (result.matchType) {
             return result.comparisonResult;
         }
-        return Long.valueOf(first.toString()).compareTo(Long.valueOf(second.toString()));
+        result = compareWithTransformation(Long.class, first, second, it -> Long.valueOf(it.toString()));
+        if (result.matchType) {
+            return result.comparisonResult;
+        }
+        throw new IllegalArgumentException(
+                String.format("comparison of %s and %s is not supported", first.getClass(), second.getClass())
+        );
     }
 
     @Override

--- a/src/main/java/com/exactpro/th2/sailfish/utils/filter/precision/DecimalFilterWithPrecision.java
+++ b/src/main/java/com/exactpro/th2/sailfish/utils/filter/precision/DecimalFilterWithPrecision.java
@@ -21,6 +21,7 @@ import com.exactpro.th2.sailfish.utils.FilterSettings;
 import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
 public class DecimalFilterWithPrecision extends AbstractFilterWithPrecision {
 
@@ -38,15 +39,23 @@ public class DecimalFilterWithPrecision extends AbstractFilterWithPrecision {
         try {
             if (value instanceof String) {
                 return new BigDecimal((String) value);
-            } else if (value instanceof BigDecimal) {
+            }
+            if (value instanceof BigDecimal) {
                 return (BigDecimal) value;
-            } else if (value instanceof Float) {
+            }
+            if (value instanceof BigInteger) {
+                return new BigDecimal(((BigInteger) value));
+            }
+            if (value instanceof Float) {
                 return BigDecimal.valueOf((Float) value);
-            } else if (value instanceof Double) {
+            }
+            if (value instanceof Double) {
                 return BigDecimal.valueOf((Double) value);
-            } else if (value instanceof Short) {
+            }
+            if (value instanceof Short) {
                 return new BigDecimal((Short) value);
-            } else if (value instanceof Integer) {
+            }
+            if (value instanceof Integer) {
                 return new BigDecimal((Integer) value);
             }
             throw new IllegalArgumentException("Value cannot be converted to decimal value. Value = " + value);

--- a/src/main/java/com/exactpro/th2/sailfish/utils/filter/util/FilterUtils.java
+++ b/src/main/java/com/exactpro/th2/sailfish/utils/filter/util/FilterUtils.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.text.DecimalFormatSymbols;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -51,7 +52,11 @@ public class FilterUtils {
         if (value.contains(DEFAULT_DECIMAL_SEPARATOR)) {
             return new BigDecimal(value);
         }
-        return Long.parseLong(value);
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException ex) {
+            return new BigInteger(value);
+        }
     }
 
     @Nullable

--- a/src/main/kotlin/com/exactpro/th2/sailfish/utils/transport/TransportToIMessageConverter.kt
+++ b/src/main/kotlin/com/exactpro/th2/sailfish/utils/transport/TransportToIMessageConverter.kt
@@ -46,8 +46,10 @@ import com.exactpro.th2.sailfish.utils.ToSailfishParameters
 import com.exactpro.th2.sailfish.utils.UnknownEnumException
 import com.exactpro.th2.sailfish.utils.filter.util.FilterUtils.NULL_VALUE
 import com.exactpro.th2.sailfish.utils.filter.util.FilterUtils.NullValue
+import com.exactpro.th2.sailfish.utils.transport.converter.BigIntegerConverter
 import mu.KotlinLogging
 import org.apache.commons.lang3.BooleanUtils
+import java.math.BigInteger
 import java.util.EnumMap
 import java.util.function.BiFunction
 
@@ -141,6 +143,7 @@ class TransportToIMessageConverter @JvmOverloads constructor(
     private fun Any?.traverseField(fieldName: String): Any? {
         return when (this) {
             null -> nullValue()
+            is BigInteger -> BigIntegerConverter.convertToString(this)
             is Number -> MultiConverter.convert(this, String::class.java)
             is String -> this
             is Map<*, *> -> convertWithoutDictionary(fieldName)
@@ -286,8 +289,12 @@ class TransportToIMessageConverter @JvmOverloads constructor(
         private fun <T> convertJavaType(value: Any, javaType: JavaType): T {
             val converter = CONVERTERS[javaType]
                 ?: throw ConversionException("No converter for type: " + javaType.value())
+
             @Suppress("UNCHECKED_CAST")
-            return converter.convert(value) as T
+            return when (value) {
+                is BigInteger -> BigIntegerConverter.convert(value, javaType)
+                else -> converter.convert(value)
+            }  as T
         }
     }
 }

--- a/src/main/kotlin/com/exactpro/th2/sailfish/utils/transport/converter/BigIntegerConverter.kt
+++ b/src/main/kotlin/com/exactpro/th2/sailfish/utils/transport/converter/BigIntegerConverter.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.exactpro.th2.sailfish.utils.transport.converter
 
 import com.exactpro.sf.common.impl.messages.xml.configuration.JavaType

--- a/src/main/kotlin/com/exactpro/th2/sailfish/utils/transport/converter/BigIntegerConverter.kt
+++ b/src/main/kotlin/com/exactpro/th2/sailfish/utils/transport/converter/BigIntegerConverter.kt
@@ -1,0 +1,27 @@
+package com.exactpro.th2.sailfish.utils.transport.converter
+
+import com.exactpro.sf.common.impl.messages.xml.configuration.JavaType
+import java.math.BigInteger
+
+internal object BigIntegerConverter {
+    fun convertToString(value: BigInteger): String = value.toString()
+
+    fun convert(value: BigInteger, target: JavaType): Any {
+        return when (target) {
+            JavaType.JAVA_LANG_SHORT -> value.shortValueExact()
+            JavaType.JAVA_LANG_INTEGER -> value.intValueExact()
+            JavaType.JAVA_LANG_LONG -> value.longValueExact()
+            JavaType.JAVA_LANG_BYTE -> value.byteValueExact()
+            JavaType.JAVA_LANG_FLOAT -> value.toFloat()
+            JavaType.JAVA_LANG_DOUBLE -> value.toDouble()
+            JavaType.JAVA_LANG_STRING -> convertToString(value)
+            JavaType.JAVA_MATH_BIG_DECIMAL -> value.toBigDecimal()
+            JavaType.JAVA_TIME_LOCAL_DATE_TIME,
+            JavaType.JAVA_TIME_LOCAL_DATE,
+            JavaType.JAVA_TIME_LOCAL_TIME,
+            JavaType.JAVA_LANG_CHARACTER,
+            JavaType.JAVA_LANG_BOOLEAN,
+            -> throw IllegalArgumentException("cannot convert from ${BigInteger::class.simpleName} to $target")
+        }
+    }
+}

--- a/src/test/kotlin/com/exactpro/th2/sailfish/utils/transport/TransportToIMessageConverterBigIntegerTest.kt
+++ b/src/test/kotlin/com/exactpro/th2/sailfish/utils/transport/TransportToIMessageConverterBigIntegerTest.kt
@@ -1,0 +1,120 @@
+package com.exactpro.th2.sailfish.utils.transport
+
+import com.exactpro.sf.common.impl.messages.xml.configuration.JavaType
+import com.exactpro.sf.common.messages.IMessage
+import com.exactpro.sf.common.messages.structures.StructureType
+import com.exactpro.sf.common.messages.structures.impl.DictionaryStructure
+import com.exactpro.sf.common.messages.structures.impl.FieldStructure
+import com.exactpro.sf.common.messages.structures.impl.MessageStructure
+import com.exactpro.th2.common.grpc.FilterOperation
+import com.exactpro.th2.common.grpc.MessageFilter
+import com.exactpro.th2.common.grpc.ValueFilter
+import com.exactpro.th2.common.message.addField
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.transport.MessageId
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.transport.ParsedMessage
+import com.exactpro.th2.sailfish.utils.ProtoToIMessageConverter
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+
+internal class TransportToIMessageConverterBigIntegerTest : AbstractTransportToIMessageConverterTest() {
+
+    @Test
+    fun `converts big integer without dictionary`() {
+        val converter = TransportToIMessageConverter()
+
+        val message = ParsedMessage.builder()
+            .addField("bigInt", "18446744073705051616".toBigInteger())
+            .setId(MessageId.DEFAULT)
+            .setType("test")
+            .build()
+
+        val wrapper: IMessage = converter.fromTransport(BOOK, SESSION_GROUP, message, false)
+        Assertions.assertEquals(
+            "18446744073705051616",
+            wrapper.getField("bigInt"),
+        ) {
+            "unexpected value in message $wrapper"
+        }
+    }
+
+    @Test
+    fun `converts big integer with dictionary`() {
+        val dictionary = DictionaryStructure(
+            "test",
+            "description",
+            emptyMap(), // no attributes
+            mapOf(
+                "test" to MessageStructure(
+                    "test",
+                    "test",
+                    "description",
+                    mapOf(
+                        "bigInt" to FieldStructure(
+                            "bitInt",
+                            "test",
+                            JavaType.JAVA_MATH_BIG_DECIMAL,
+                            false, // not a collection
+                            StructureType.SIMPLE,
+                        )
+                    ),
+                    emptyMap(), // no attributes
+                    null, // no reference
+                )
+            ),
+            emptyMap(), // no fields
+        )
+        val converter = TransportToIMessageConverter(dictionary = dictionary)
+
+        val message = ParsedMessage.builder()
+            .addField("bigInt", "18446744073705051616".toBigInteger())
+            .setId(MessageId.DEFAULT)
+            .setType("test")
+            .build()
+
+        val wrapper: IMessage = converter.fromTransport(BOOK, SESSION_GROUP, message, true)
+        Assertions.assertEquals(
+            "18446744073705051616".toBigDecimal(),
+            wrapper.getField("bigInt"),
+        ) {
+            "unexpected value in message $wrapper"
+        }
+    }
+
+    @TestFactory
+    fun `compare filter handles big integer`(): List<DynamicTest> {
+        val protoConverter = ProtoToIMessageConverter()
+        val converter = TransportToIMessageConverter()
+
+        return listOf(
+            "18446744073705051617" to FilterOperation.LESS,
+            "18446744073705051616" to FilterOperation.NOT_MORE,
+            "18446744073705051615" to FilterOperation.MORE,
+            "18446744073705051616" to FilterOperation.NOT_LESS,
+            "18446744073705051616" to FilterOperation.EQ_DECIMAL_PRECISION,
+        ).map { (filterValue, filterOp) ->
+            DynamicTest.dynamicTest("$filterValue $filterOp") {
+                val filter = protoConverter.fromProtoFilter(
+                    MessageFilter.newBuilder()
+                        .putFields(
+                            "bigInt", ValueFilter.newBuilder()
+                                .setOperation(filterOp)
+                                .setSimpleFilter(filterValue)
+                                .build()
+                        ).build(),
+                    "test",
+                )
+                val message = ParsedMessage.builder()
+                    .addField("bigInt", "18446744073705051616".toBigInteger())
+                    .setId(MessageId.DEFAULT)
+                    .setType("test")
+                    .build()
+
+                val wrapper = converter.fromTransport(BOOK, SESSION_GROUP, message, false)
+
+                assertPassed(filter, wrapper)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/exactpro/th2/sailfish/utils/transport/TransportToIMessageConverterBigIntegerTest.kt
+++ b/src/test/kotlin/com/exactpro/th2/sailfish/utils/transport/TransportToIMessageConverterBigIntegerTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.exactpro.th2.sailfish.utils.transport
 
 import com.exactpro.sf.common.impl.messages.xml.configuration.JavaType


### PR DESCRIPTION
There might be cases when an integer is too big to fit the `Long` type (if the original type is uint64 for example).
This change adds support for such values to converter and comparison filters